### PR TITLE
feat: #24 jwt 클레임 추가 및 user 추가정보 저장, 커플 연결

### DIFF
--- a/src/main/java/com/momentree/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/momentree/domain/auth/controller/AuthController.java
@@ -1,6 +1,6 @@
 package com.momentree.domain.auth.controller;
 
-import com.momentree.domain.auth.response.AccessTokenResponseDto;
+import com.momentree.domain.auth.dto.response.AccessTokenResponseDto;
 import com.momentree.domain.auth.service.AuthService;
 import com.momentree.global.exception.BaseException;
 import com.momentree.global.exception.BaseResponse;

--- a/src/main/java/com/momentree/domain/auth/dto/response/AccessTokenResponseDto.java
+++ b/src/main/java/com/momentree/domain/auth/dto/response/AccessTokenResponseDto.java
@@ -1,4 +1,4 @@
-package com.momentree.domain.auth.response;
+package com.momentree.domain.auth.dto.response;
 
 public record AccessTokenResponseDto(String refreshedAccessToken) {
 }

--- a/src/main/java/com/momentree/domain/auth/jwt/AccessTokenProvider.java
+++ b/src/main/java/com/momentree/domain/auth/jwt/AccessTokenProvider.java
@@ -33,13 +33,14 @@ public class AccessTokenProvider {
         key = Keys.hmacShaKeyFor(byteSecretKey);
     }
 
-    public String generateAccessToken(String username, String role) {
-        return createJwt(username, role, tokenProperty.getAccessTokenExpiration());
+    public String generateAccessToken(Long userId, String username, String role) {
+        return createJwt(userId, username, role, tokenProperty.getAccessTokenExpiration());
     }
 
-    public String createJwt(String username, String role, Long expirationTime) {
+    public String createJwt(Long userId, String username, String role, Long expirationTime) {
         long now = System.currentTimeMillis();
         return Jwts.builder()
+                .claim("userId", userId)
                 .claim("username", username)
                 .claim("role", role)
                 .setIssuedAt(new Date(now))
@@ -78,7 +79,9 @@ public class AccessTokenProvider {
                 .getBody();
 
         Long userId = claims.get("userId", Long.class);
+        log.info("토큰!userId={}", userId);
         String username = claims.get("username", String.class);
+        log.info("토큰!userId={}", username);
         String role = claims.get("role", String.class);
 
         User user = User.builder()

--- a/src/main/java/com/momentree/domain/auth/jwt/AccessTokenProvider.java
+++ b/src/main/java/com/momentree/domain/auth/jwt/AccessTokenProvider.java
@@ -79,9 +79,7 @@ public class AccessTokenProvider {
                 .getBody();
 
         Long userId = claims.get("userId", Long.class);
-        log.info("토큰!userId={}", userId);
         String username = claims.get("username", String.class);
-        log.info("토큰!userId={}", username);
         String role = claims.get("role", String.class);
 
         User user = User.builder()
@@ -101,7 +99,9 @@ public class AccessTokenProvider {
         Map<String, Object> responseBody = new HashMap<>();
         responseBody.put("accessToken", accessToken);
         responseBody.put("isFirstLogin", customUserDetails.isFirstLogin());
-        log.info("isFirstLogin={}", customUserDetails.isFirstLogin());
+        if(customUserDetails.getCoupleId() == null) {
+            responseBody.put("userCode", customUserDetails.getUserCode());
+        }
 
         new ObjectMapper().writeValue(response.getWriter(), responseBody);
     }

--- a/src/main/java/com/momentree/domain/auth/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/momentree/domain/auth/oauth2/CustomOAuth2User.java
@@ -46,4 +46,13 @@ public class CustomOAuth2User implements OAuth2User {
     public boolean isFirstLogin() {
         return isFirstLogin;
     }
+
+    public String getUserCode() {
+        return user.getUserCode();
+    }
+
+    public Long getCoupleId() {
+        return user.getCouple() == null ? null : user.getCouple().getId();
+    }
+
 }

--- a/src/main/java/com/momentree/domain/auth/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/momentree/domain/auth/oauth2/CustomSuccessHandler.java
@@ -26,6 +26,7 @@ public class CustomSuccessHandler implements AuthenticationSuccessHandler {
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+        Long userId = customUserDetails.getUserId();
         String username = customUserDetails.getName();
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
@@ -34,7 +35,7 @@ public class CustomSuccessHandler implements AuthenticationSuccessHandler {
         String role = auth.getAuthority();
 
         // 토큰 발급
-        String accessToken = accessTokenProvider.generateAccessToken(username, role);
+        String accessToken = accessTokenProvider.generateAccessToken(userId, username, role);
         String refreshToken = refreshTokenProvider.createAndStoreRefreshToken(customUserDetails.getUserId());
 
         // 리프레시 토큰을 쿠키로 설정

--- a/src/main/java/com/momentree/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/momentree/domain/auth/service/impl/AuthServiceImpl.java
@@ -24,6 +24,6 @@ public class AuthServiceImpl implements AuthService {
         if (user == null) {
             throw new BaseException(ErrorCode.INVALID_JWT);
         }
-        return accessTokenProvider.generateAccessToken(user.getUsername(), String.valueOf(user.getRole()));
+        return accessTokenProvider.generateAccessToken(user.getId(), user.getUsername(), String.valueOf(user.getRole()));
     }
 }

--- a/src/main/java/com/momentree/domain/couple/controller/CoupleController.java
+++ b/src/main/java/com/momentree/domain/couple/controller/CoupleController.java
@@ -1,0 +1,28 @@
+package com.momentree.domain.couple.controller;
+
+import com.momentree.domain.auth.oauth2.CustomOAuth2User;
+import com.momentree.domain.couple.dto.request.CoupleConnectRequestDto;
+import com.momentree.domain.couple.dto.response.CoupleConnectResponseDto;
+import com.momentree.domain.couple.service.CoupleService;
+import com.momentree.global.exception.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/couple")
+public class CoupleController {
+
+    private final CoupleService coupleService;
+
+    @PostMapping("/connect")
+    public BaseResponse<CoupleConnectResponseDto> connectCouple(
+            @AuthenticationPrincipal CustomOAuth2User userDetails,
+            @RequestBody CoupleConnectRequestDto requestDto){
+        Long userId = userDetails.getUserId();
+        CoupleConnectResponseDto connectResponse = coupleService.connectCouple(userId, requestDto);
+        return new BaseResponse<>(connectResponse);
+    }
+
+}

--- a/src/main/java/com/momentree/domain/couple/dto/request/CoupleConnectRequestDto.java
+++ b/src/main/java/com/momentree/domain/couple/dto/request/CoupleConnectRequestDto.java
@@ -1,0 +1,7 @@
+package com.momentree.domain.couple.dto.request;
+
+public record CoupleConnectRequestDto(
+        String userCode,
+        String coupleStartedDay
+) {
+}

--- a/src/main/java/com/momentree/domain/couple/dto/response/CoupleConnectResponseDto.java
+++ b/src/main/java/com/momentree/domain/couple/dto/response/CoupleConnectResponseDto.java
@@ -1,0 +1,17 @@
+package com.momentree.domain.couple.dto.response;
+
+import java.time.LocalDate;
+
+public record CoupleConnectResponseDto(Long userId1,
+                                       Long userId2,
+                                       LocalDate coupleStartedDay) {
+    public static CoupleConnectResponseDto from(Long userId1,
+                                                Long userId2,
+                                                LocalDate coupleStartedDate) {
+        return new CoupleConnectResponseDto(
+                userId1,
+                userId2,
+                coupleStartedDate
+        );
+    }
+}

--- a/src/main/java/com/momentree/domain/couple/entity/Couple.java
+++ b/src/main/java/com/momentree/domain/couple/entity/Couple.java
@@ -24,4 +24,10 @@ public class Couple extends BaseEntity {
     @Column(name = "couple_nickname")
     private String coupleNickname;
 
+    public static Couple from(LocalDate coupleStartedDay) {
+        return Couple.builder()
+                .coupleStartedDay(coupleStartedDay)
+                .build();
+    }
+
 }

--- a/src/main/java/com/momentree/domain/couple/repository/CoupleRepository.java
+++ b/src/main/java/com/momentree/domain/couple/repository/CoupleRepository.java
@@ -1,0 +1,7 @@
+package com.momentree.domain.couple.repository;
+
+import com.momentree.domain.couple.entity.Couple;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoupleRepository extends JpaRepository<Couple, Long> {
+}

--- a/src/main/java/com/momentree/domain/couple/service/CoupleService.java
+++ b/src/main/java/com/momentree/domain/couple/service/CoupleService.java
@@ -1,0 +1,8 @@
+package com.momentree.domain.couple.service;
+
+import com.momentree.domain.couple.dto.request.CoupleConnectRequestDto;
+import com.momentree.domain.couple.dto.response.CoupleConnectResponseDto;
+
+public interface CoupleService {
+    CoupleConnectResponseDto connectCouple(Long userId, CoupleConnectRequestDto requestDto);
+}

--- a/src/main/java/com/momentree/domain/couple/service/impl/CoupleServiceImpl.java
+++ b/src/main/java/com/momentree/domain/couple/service/impl/CoupleServiceImpl.java
@@ -1,0 +1,56 @@
+package com.momentree.domain.couple.service.impl;
+
+import com.momentree.domain.couple.dto.request.CoupleConnectRequestDto;
+import com.momentree.domain.couple.dto.response.CoupleConnectResponseDto;
+import com.momentree.domain.couple.entity.Couple;
+import com.momentree.domain.couple.repository.CoupleRepository;
+import com.momentree.domain.couple.service.CoupleService;
+import com.momentree.domain.user.entity.User;
+import com.momentree.domain.user.repository.UserRepository;
+import com.momentree.global.exception.BaseException;
+import com.momentree.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class CoupleServiceImpl implements CoupleService {
+
+    private final UserRepository userRepository;
+    private final CoupleRepository coupleRepository;
+
+    @Override
+    @Transactional
+    public CoupleConnectResponseDto connectCouple(Long userId, CoupleConnectRequestDto requestDto) {
+        User user1 = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_USER));
+
+        User user2 = userRepository.findByUserCode(requestDto.userCode())
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_USER));
+
+        // 자신의 코드로 연결하려는 경우
+        if (requestDto.userCode().equals(user1.getUserCode())) {
+            throw new BaseException(ErrorCode.CANNOT_CONNECT_SELF);
+        }
+
+        // 이미 커플이 연결된 상태인지 확인
+        if (user1.getCouple() != null || user2.getCouple() != null) {
+            throw new BaseException(ErrorCode.ALREADY_CONNECTED_COUPLE);
+        }
+
+        Couple couple = Couple.from(LocalDate.parse(requestDto.coupleStartedDay()));
+        Couple savedCouple = coupleRepository.save(couple);
+
+        user1.assignCouple(savedCouple);
+        user2.assignCouple(savedCouple);
+
+        // 변경된 User 저장
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        return CoupleConnectResponseDto.from(user1.getId(), user2.getId(), savedCouple.getCoupleStartedDay());
+    }
+}

--- a/src/main/java/com/momentree/domain/user/controller/UserController.java
+++ b/src/main/java/com/momentree/domain/user/controller/UserController.java
@@ -1,0 +1,33 @@
+package com.momentree.domain.user.controller;
+
+import com.momentree.domain.auth.oauth2.CustomOAuth2User;
+import com.momentree.domain.user.dto.request.UserAdditionalInfoRequestDto;
+import com.momentree.domain.user.dto.response.UserAdditionalInfoResponseDto;
+import com.momentree.domain.user.service.UserService;
+import com.momentree.global.exception.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/user")
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/additional-info")
+    public BaseResponse<UserAdditionalInfoResponseDto> patchUserAdditionalInfo(
+            @AuthenticationPrincipal CustomOAuth2User userDetails,
+            @RequestBody UserAdditionalInfoRequestDto requestDto) {
+        Long userId = userDetails.getUserId();
+        UserAdditionalInfoResponseDto responseDto = userService.patchUserAdditionalInfo(userId, requestDto);
+        return new BaseResponse<>(responseDto);
+    }
+
+}

--- a/src/main/java/com/momentree/domain/user/dto/request/UserAdditionalInfoRequestDto.java
+++ b/src/main/java/com/momentree/domain/user/dto/request/UserAdditionalInfoRequestDto.java
@@ -1,0 +1,9 @@
+package com.momentree.domain.user.dto.request;
+
+public record UserAdditionalInfoRequestDto(
+        String birth,
+        String location,
+        String statusMessage,
+        Boolean marketingConsent
+) {
+}

--- a/src/main/java/com/momentree/domain/user/dto/response/UserAdditionalInfoResponseDto.java
+++ b/src/main/java/com/momentree/domain/user/dto/response/UserAdditionalInfoResponseDto.java
@@ -1,0 +1,24 @@
+package com.momentree.domain.user.dto.response;
+
+import com.momentree.domain.user.entity.User;
+
+import java.time.LocalDate;
+
+public record UserAdditionalInfoResponseDto(Long userId,
+                                            LocalDate birth,
+                                            String location,
+                                            String statusMessage,
+                                            String userCode,
+                                            Boolean marketingConsent) {
+    public static UserAdditionalInfoResponseDto from(User user) {
+        return new UserAdditionalInfoResponseDto(
+                user.getId(),
+                user.getBirth(),
+                user.getLocation(),
+                user.getStatusMessage(),
+                user.getUserCode(),
+                user.getMarketingConsent()
+        );
+    }
+
+}

--- a/src/main/java/com/momentree/domain/user/entity/User.java
+++ b/src/main/java/com/momentree/domain/user/entity/User.java
@@ -74,6 +74,10 @@ public class User extends BaseEntity {
                 .build();
     }
 
+    public void assignCouple(Couple couple) {
+        this.couple = couple;
+    }
+
     public void updateUserAdditionalInfo(UserAdditionalInfoRequestDto requestDto) {
         if (requestDto.birth() != null) this.birth = LocalDate.parse(requestDto.birth());
         if (requestDto.location() != null) this.location = requestDto.location();

--- a/src/main/java/com/momentree/domain/user/entity/User.java
+++ b/src/main/java/com/momentree/domain/user/entity/User.java
@@ -74,5 +74,11 @@ public class User extends BaseEntity {
                 .build();
     }
 
+    public void updateUserAdditionalInfo(UserAdditionalInfoRequestDto requestDto) {
+        if (requestDto.birth() != null) this.birth = LocalDate.parse(requestDto.birth());
+        if (requestDto.location() != null) this.location = requestDto.location();
+        if (requestDto.statusMessage() != null) this.statusMessage = requestDto.statusMessage();
+        this.marketingConsent = requestDto.marketingConsent() != null ? true : false;
+    }
 
 }

--- a/src/main/java/com/momentree/domain/user/entity/User.java
+++ b/src/main/java/com/momentree/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.momentree.domain.user.entity;
 
 import com.momentree.domain.auth.oauth2.OAuth2UserInfo;
 import com.momentree.domain.couple.entity.Couple;
+import com.momentree.domain.user.dto.request.UserAdditionalInfoRequestDto;
 import com.momentree.global.entity.BaseEntity;
 import com.momentree.global.constant.Role;
 import com.momentree.global.constant.Status;
@@ -28,9 +29,6 @@ public class User extends BaseEntity {
     @Column(name = "email", nullable = false)
     private String email;
 
-    @Column(name = "birth", nullable = true)
-    private LocalDate birth;
-
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
     private Status status;
@@ -41,6 +39,18 @@ public class User extends BaseEntity {
 
     @Column(name = "user_code", nullable = false)
     private String userCode;
+
+    @Column(name = "birth")
+    private LocalDate birth;
+
+    @Column(name = "location")
+    private String location;
+
+    @Column(name = "marketingConsent")
+    private Boolean marketingConsent;
+
+    @Column(name = "statusMessage")
+    private String statusMessage;
 
     @Column(name = "provider", nullable = false)
     private String provider;
@@ -63,5 +73,6 @@ public class User extends BaseEntity {
                 .role(Role.USER)
                 .build();
     }
+
 
 }

--- a/src/main/java/com/momentree/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/momentree/domain/user/repository/UserRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderIdAndProvider(String providerId, String provider);
-
     boolean existsByUserCode(String userCode);
+    Optional<User> findByUserCode(String userCode);
 }

--- a/src/main/java/com/momentree/domain/user/service/UserService.java
+++ b/src/main/java/com/momentree/domain/user/service/UserService.java
@@ -1,0 +1,8 @@
+package com.momentree.domain.user.service;
+
+import com.momentree.domain.user.dto.request.UserAdditionalInfoRequestDto;
+import com.momentree.domain.user.dto.response.UserAdditionalInfoResponseDto;
+
+public interface UserService {
+    UserAdditionalInfoResponseDto patchUserAdditionalInfo(Long userId, UserAdditionalInfoRequestDto requestDto);
+}

--- a/src/main/java/com/momentree/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/momentree/domain/user/service/impl/UserServiceImpl.java
@@ -1,0 +1,30 @@
+package com.momentree.domain.user.service.impl;
+
+import com.momentree.domain.user.entity.User;
+import com.momentree.domain.user.repository.UserRepository;
+import com.momentree.domain.user.dto.request.UserAdditionalInfoRequestDto;
+import com.momentree.domain.user.dto.response.UserAdditionalInfoResponseDto;
+import com.momentree.domain.user.service.UserService;
+import com.momentree.global.exception.BaseException;
+import com.momentree.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserAdditionalInfoResponseDto patchUserAdditionalInfo(Long userId, UserAdditionalInfoRequestDto requestDto) {
+        User findedUser = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_USER));
+
+        findedUser.updateUserAdditionalInfo(requestDto);
+        User updatedUser = userRepository.save(findedUser);
+        return UserAdditionalInfoResponseDto.from(updatedUser);
+    }
+}

--- a/src/main/java/com/momentree/global/exception/ErrorCode.java
+++ b/src/main/java/com/momentree/global/exception/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
      * 400 : Request, Response 오류
      */
     NOT_FOUND_USER(HttpStatus.NOT_FOUND.value(), "일치하는 유저가 없습니다."),
+    ALREADY_CONNECTED_COUPLE(HttpStatus.BAD_REQUEST.value(), "이미 커플이 연결된 상태입니다."),
+    CANNOT_CONNECT_SELF(HttpStatus.BAD_REQUEST.value(), "자기 자신과는 커플 연결을 할 수 없습니다."),
 
     /**
      * 400 : Validation Error


### PR DESCRIPTION
## ✨ Feature: 기능 개발

### 📝 작업 개요 (Summary)
- 개발하려는 기능을 한 줄로 명확하게 요약

### 🎯 목표 및 완료 조건 (Goals / Done Criteria)
- [X] jwt 액세스 토큰에 userId 클레임 추가
- [X] user 추가정보(생일, 위치, 상태메시지, 마케팅 수신 여부) 저장
- [X] userCode를 입력해 상대방과 커플로 연결하는 기능 구현

### 📋 구현 상세 (Details)
커플 연결:
- userCode를 기반으로 상대방 조회
- 양쪽 모두 Couple 객체 참조 저장
- 자신의 userCode로 커플 연결 불가(CANNOT_CONNECT_SELF) 
- 이미 연결된 경우 예외 처리 (ALREADY_CONNECTED_COUPLE)

### 🧩 영향 범위
- User, Couple, CustomOAuth2User 인증 및 도메인 로직 전반