### PR TITLE
bug: #28 소셜 로그인 후 access 토큰 body 반환 방식을 redirect후 api요청으로 수정

### DIFF
--- a/src/main/java/com/momentree/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/momentree/domain/auth/controller/AuthController.java
@@ -1,6 +1,6 @@
 package com.momentree.domain.auth.controller;
 
-import com.momentree.domain.auth.dto.response.AccessTokenResponseDto;
+import com.momentree.domain.auth.dto.response.AccessTokenWithUserResponseDto;
 import com.momentree.domain.auth.service.AuthService;
 import com.momentree.global.exception.BaseException;
 import com.momentree.global.exception.BaseResponse;
@@ -23,6 +23,15 @@ public class AuthController {
     @GetMapping("/refresh-token")
     public BaseResponse<?> refreshAccessToken(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
+        String refreshToken = extractRefreshTokenFromCookies(cookies);
+
+        // Access Token 발급
+        AccessTokenWithUserResponseDto responseDto = authService.refreshAccessToken(refreshToken);
+
+        return new BaseResponse<>(responseDto);
+    }
+
+    private static String extractRefreshTokenFromCookies(Cookie[] cookies) {
         if (cookies == null) {
             throw new BaseException(ErrorCode.INVALID_JWT);
         }
@@ -38,10 +47,6 @@ public class AuthController {
         if (refreshToken == null || refreshToken.isEmpty()) {
             throw new BaseException(ErrorCode.INVALID_JWT);
         }
-
-        // Access Token 발급
-        String refreshedAccessToken = authService.refreshAccessToken(refreshToken);
-
-        return new BaseResponse<>(new AccessTokenResponseDto(refreshedAccessToken));
+        return refreshToken;
     }
 }

--- a/src/main/java/com/momentree/domain/auth/dto/response/AccessTokenResponseDto.java
+++ b/src/main/java/com/momentree/domain/auth/dto/response/AccessTokenResponseDto.java
@@ -1,4 +1,0 @@
-package com.momentree.domain.auth.dto.response;
-
-public record AccessTokenResponseDto(String refreshedAccessToken) {
-}

--- a/src/main/java/com/momentree/domain/auth/dto/response/AccessTokenWithUserResponseDto.java
+++ b/src/main/java/com/momentree/domain/auth/dto/response/AccessTokenWithUserResponseDto.java
@@ -1,0 +1,20 @@
+package com.momentree.domain.auth.dto.response;
+
+public record AccessTokenWithUserResponseDto(String accessToken,
+                                             String username,
+                                             String email,
+                                             String userCode,
+                                             Long coupleId
+) {
+    public AccessTokenWithUserResponseDto(String accessToken,
+                                          String username,
+                                          String email,
+                                          String userCode,
+                                          Long coupleId) {
+        this.accessToken = accessToken;
+        this.username = username;
+        this.email = email;
+        this.userCode = userCode;
+        this.coupleId = coupleId;
+    }
+}

--- a/src/main/java/com/momentree/domain/auth/jwt/AccessTokenProvider.java
+++ b/src/main/java/com/momentree/domain/auth/jwt/AccessTokenProvider.java
@@ -1,6 +1,5 @@
 package com.momentree.domain.auth.jwt;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.momentree.domain.auth.oauth2.CustomOAuth2User;
 import com.momentree.domain.user.entity.User;
 import com.momentree.global.constant.Role;
@@ -9,17 +8,13 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.security.Key;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
 @Slf4j
 @Component
@@ -90,20 +85,6 @@ public class AccessTokenProvider {
 
         CustomOAuth2User customOAuth2User = new CustomOAuth2User(user, false);
         return new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
-    }
-
-    public void setAccessTokenBody(HttpServletResponse response, String accessToken, CustomOAuth2User customUserDetails) throws IOException {
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-
-        Map<String, Object> responseBody = new HashMap<>();
-        responseBody.put("accessToken", accessToken);
-        responseBody.put("isFirstLogin", customUserDetails.isFirstLogin());
-        if(customUserDetails.getCoupleId() == null) {
-            responseBody.put("userCode", customUserDetails.getUserCode());
-        }
-
-        new ObjectMapper().writeValue(response.getWriter(), responseBody);
     }
 
 }

--- a/src/main/java/com/momentree/domain/auth/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/momentree/domain/auth/oauth2/CustomSuccessHandler.java
@@ -1,50 +1,39 @@
 package com.momentree.domain.auth.oauth2;
 
-import com.momentree.domain.auth.jwt.AccessTokenProvider;
 import com.momentree.domain.auth.jwt.RefreshTokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class CustomSuccessHandler implements AuthenticationSuccessHandler {
 
-    private final AccessTokenProvider accessTokenProvider;
     private final RefreshTokenProvider refreshTokenProvider;
+
+    @Value("${custom.dev.frontUrl}")
+    private String frontUrl;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
-        Long userId = customUserDetails.getUserId();
-        String username = customUserDetails.getName();
-
-        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
-        GrantedAuthority auth = iterator.next();
-        String role = auth.getAuthority();
 
         // 토큰 발급
-        String accessToken = accessTokenProvider.generateAccessToken(userId, username, role);
         String refreshToken = refreshTokenProvider.createAndStoreRefreshToken(customUserDetails.getUserId());
 
         // 리프레시 토큰을 쿠키로 설정
         refreshTokenProvider.setRefreshTokenCookie(response, refreshToken);
 
-        // 액세스 토큰을 바디로 설정
-        accessTokenProvider.setAccessTokenBody(response, accessToken, customUserDetails);
+        response.sendRedirect(frontUrl + "/login/oauth2/success");
 
-        log.info("accessToken={}", accessToken);
         log.info("refreshToken={}", refreshToken);
     }
 

--- a/src/main/java/com/momentree/domain/auth/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/com/momentree/domain/auth/oauth2/CustomSuccessHandler.java
@@ -33,8 +33,6 @@ public class CustomSuccessHandler implements AuthenticationSuccessHandler {
         refreshTokenProvider.setRefreshTokenCookie(response, refreshToken);
 
         response.sendRedirect(frontUrl + "/login/oauth2/success");
-
-        log.info("refreshToken={}", refreshToken);
     }
 
 }

--- a/src/main/java/com/momentree/domain/auth/service/AuthService.java
+++ b/src/main/java/com/momentree/domain/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.momentree.domain.auth.service;
 
+import com.momentree.domain.auth.dto.response.AccessTokenWithUserResponseDto;
+
 public interface AuthService {
-    String refreshAccessToken(String refreshToken);
+    AccessTokenWithUserResponseDto refreshAccessToken(String refreshToken);
 }

--- a/src/main/java/com/momentree/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/momentree/domain/auth/service/impl/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package com.momentree.domain.auth.service.impl;
 
+import com.momentree.domain.auth.dto.response.AccessTokenWithUserResponseDto;
 import com.momentree.domain.auth.jwt.AccessTokenProvider;
 import com.momentree.domain.auth.jwt.RefreshTokenProvider;
 import com.momentree.domain.auth.service.AuthService;
@@ -19,11 +20,18 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public String refreshAccessToken(String refreshToken) {
+    public AccessTokenWithUserResponseDto refreshAccessToken(String refreshToken) {
         User user = refreshTokenProvider.validateRefreshToken(refreshToken);
         if (user == null) {
             throw new BaseException(ErrorCode.INVALID_JWT);
         }
-        return accessTokenProvider.generateAccessToken(user.getId(), user.getUsername(), String.valueOf(user.getRole()));
+        String accessToken = accessTokenProvider.generateAccessToken(user.getId(), user.getUsername(), String.valueOf(user.getRole()));
+        return new AccessTokenWithUserResponseDto(
+                accessToken,
+                user.getUsername(),
+                user.getEmail(),
+                user.getUserCode(),
+                user.getCouple() == null ? null : user.getCouple().getId()
+        );
     }
 }

--- a/src/main/java/com/momentree/domain/couple/service/impl/CoupleServiceImpl.java
+++ b/src/main/java/com/momentree/domain/couple/service/impl/CoupleServiceImpl.java
@@ -33,9 +33,6 @@ public class CoupleServiceImpl implements CoupleService {
         User user2 = userRepository.findByUserCode(requestDto.userCode())
                 .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_USER));
 
-        log.info("user1={}", user1.getId());
-        log.info("user2={}", user2.getId());
-
         // 자신의 코드로 연결하려는 경우
         if (requestDto.userCode().equals(user1.getUserCode())) {
             throw new BaseException(ErrorCode.CANNOT_CONNECT_SELF);

--- a/src/main/java/com/momentree/domain/couple/service/impl/CoupleServiceImpl.java
+++ b/src/main/java/com/momentree/domain/couple/service/impl/CoupleServiceImpl.java
@@ -10,11 +10,13 @@ import com.momentree.domain.user.repository.UserRepository;
 import com.momentree.global.exception.BaseException;
 import com.momentree.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CoupleServiceImpl implements CoupleService {
@@ -30,6 +32,9 @@ public class CoupleServiceImpl implements CoupleService {
 
         User user2 = userRepository.findByUserCode(requestDto.userCode())
                 .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_USER));
+
+        log.info("user1={}", user1.getId());
+        log.info("user2={}", user2.getId());
 
         // 자신의 코드로 연결하려는 경우
         if (requestDto.userCode().equals(user1.getUserCode())) {


### PR DESCRIPTION

## 🐞 Bug: 버그 수정

### 📝 버그 설명 (Description)
- 소셜 로그인 성공 시 access 토큰을 body로 반환했더니, 프론트엔드에서 해당 토큰을 읽고 페이지를 리다이렉트할 수 없는 문제가 발생함

### 🔁 재현 방법 (Steps to Reproduce)
1. 소셜 로그인 시도 (예: 구글 로그인)
2. 백엔드에서 access 토큰을 HTTP response body에 담아 반환
3. 프론트엔드에서 해당 토큰을 읽고 리다이렉트를 시도

### 🤔 기대 결과 (Expected Result)
- 프론트엔드가 access 토큰을 정상적으로 받아서 다른 페이지로 리다이렉트할 수 있어야 함

### 😵 실제 결과 (Actual Result)
- 브라우저에서 토큰을 읽지 못하고 프론트에서 리다이렉트가 제대로 되지 않음

### 🛠️ 수정 방안/원인(선택)
- 소셜 로그인 성공 시 CustomSuccessHandler에서 
``` java
response.sendRedirect("http://localhost:5173/login/oauth2/success")
```
리다이렉트 방식으로 변경

이후 프론트에서 cookie에 있는 refreshToken으로 api를 통해 accessToken 발급 요청

### 🧩 영향 범위
- 소셜 로그인 인증 흐름
- access/refresh 토큰 발급 및 저장 로직
- 프론트엔드 소셜 로그인 이후 리다이렉트 및 인증 처리 방식