### PR TITLE
feat: #36 AWS S3 기반 프로필 이미지 업로드/삭제 기능 개발

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,10 @@ dependencies {
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
+	// AWS s3
+	implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
+	implementation("software.amazon.awssdk:s3:2.25.4")
+
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/momentree/domain/image/entity/Image.java
+++ b/src/main/java/com/momentree/domain/image/entity/Image.java
@@ -29,4 +29,10 @@ public class Image extends BaseEntity {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
+    public static Image of(String imageUrl, User user) {
+        return Image.builder()
+                .imageUrl(imageUrl)
+                .user(user)
+                .build();
+    }
 }

--- a/src/main/java/com/momentree/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/momentree/domain/image/repository/ImageRepository.java
@@ -1,0 +1,11 @@
+package com.momentree.domain.image.repository;
+
+import com.momentree.domain.image.entity.Image;
+import com.momentree.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    Optional<Image> findByUserAndPostIsNull(User user);
+}

--- a/src/main/java/com/momentree/domain/user/controller/ApiV1UserController.java
+++ b/src/main/java/com/momentree/domain/user/controller/ApiV1UserController.java
@@ -11,10 +11,15 @@ import com.momentree.domain.user.dto.request.UserAdditionalInfoRequestDto;
 import com.momentree.domain.user.dto.response.*;
 import com.momentree.domain.user.service.UserService;
 import com.momentree.global.exception.BaseResponse;
+import com.momentree.global.exception.ErrorCode;
+import com.momentree.global.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 
 @Slf4j
@@ -24,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 public class ApiV1UserController {
     private final UserService userService;
     private final CoupleService coupleService;
+    private final S3Service s3Service;
 
     // 회원가입 시 추가정보 등록 (최초 1회)
     @PatchMapping("/additional-info")
@@ -76,6 +82,19 @@ public class ApiV1UserController {
     @PostMapping("/recover")
     public BaseResponse<Void> recoverMyProfile(@AuthenticationPrincipal CustomOAuth2User loginUser) {
         return new BaseResponse<>(userService.recoverMyProfile(loginUser.getUserId()));
+    }
+
+    @PostMapping("/image")
+    public BaseResponse<String> uploadProfileImage(@AuthenticationPrincipal CustomOAuth2User loginUser,
+                                                   @RequestPart("file") MultipartFile file) throws IOException {
+        String imageUrl = s3Service.uploadProfileImage(file, loginUser.getUserId());
+        return new BaseResponse<>(imageUrl);
+    }
+
+    @DeleteMapping("/image")
+    public BaseResponse<String> deleteProfileImage(@AuthenticationPrincipal CustomOAuth2User loginUser) {
+        s3Service.deleteProfileImage(loginUser.getUserId());
+        return new BaseResponse<>(ErrorCode.NO_CONTENT);
     }
 
 }

--- a/src/main/java/com/momentree/domain/user/dto/response/GetProfileResponseDto.java
+++ b/src/main/java/com/momentree/domain/user/dto/response/GetProfileResponseDto.java
@@ -15,9 +15,10 @@ public record GetProfileResponseDto(
         Boolean marketingConsent,
         String statusMessage,
         LocalDate coupleStartedDay,
-        String partnerEmail
+        String partnerEmail,
+        String profileImageUrl
 ) {
-    public static GetProfileResponseDto of(User user, LocalDate coupleStartedDay, String partnerEmail) {
+    public static GetProfileResponseDto of(User user, LocalDate coupleStartedDay, String partnerEmail, String profileImageUrl) {
         return GetProfileResponseDto.builder()
                 .userId(user.getId())
                 .username(user.getUsername())
@@ -28,6 +29,7 @@ public record GetProfileResponseDto(
                 .statusMessage(user.getStatusMessage())
                 .coupleStartedDay(coupleStartedDay)
                 .partnerEmail(partnerEmail)
+                .profileImageUrl(profileImageUrl)
                 .build();
     }
 

--- a/src/main/java/com/momentree/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/momentree/domain/user/service/impl/UserServiceImpl.java
@@ -1,6 +1,8 @@
 package com.momentree.domain.user.service.impl;
 
 import com.momentree.domain.couple.entity.Couple;
+import com.momentree.domain.image.entity.Image;
+import com.momentree.domain.image.repository.ImageRepository;
 import com.momentree.domain.user.dto.request.PatchMarketingConsentRequestDto;
 import com.momentree.domain.user.dto.request.PatchPersonalRequestDto;
 import com.momentree.domain.user.dto.request.PatchProfileRequestDto;
@@ -23,6 +25,7 @@ import java.time.LocalDate;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final ImageRepository imageRepository;
 
     @Override
     public UserAdditionalInfoResponseDto patchUserAdditionalInfo(Long userId, UserAdditionalInfoRequestDto requestDto) {
@@ -43,9 +46,11 @@ public class UserServiceImpl implements UserService {
         LocalDate coupleStartedDay = couple.getCoupleStartedDay();
         String partnerEmail = userRepository.findPartnerEmailByCoupleAndUserId(couple, userId)
                 .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_PARTNER));
+        String profileImageUrl = imageRepository.findByUserAndPostIsNull(user)
+                .map(Image::getImageUrl)
+                .orElse(null);
 
-
-        return GetProfileResponseDto.of(user, coupleStartedDay, partnerEmail);
+        return GetProfileResponseDto.of(user, coupleStartedDay, partnerEmail, profileImageUrl);
     }
 
     @Override
@@ -92,6 +97,5 @@ public class UserServiceImpl implements UserService {
         userRepository.save(user);
         return null;
     }
-
 
 }

--- a/src/main/java/com/momentree/global/config/S3Config.java
+++ b/src/main/java/com/momentree/global/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.momentree.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials awsCreds = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCreds))
+                .build();
+    }
+}

--- a/src/main/java/com/momentree/global/exception/ErrorCode.java
+++ b/src/main/java/com/momentree/global/exception/ErrorCode.java
@@ -35,7 +35,7 @@ public enum ErrorCode {
     INVALID_JWT(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 JWT입니다."),
     INVALID_AUTHORIZATION(HttpStatus.CONFLICT.value(), "잘못된 권한입니다."),
     INVALID_SCHEDULE_DATA(HttpStatus.BAD_REQUEST.value(), "잘못된 일정 데이터가 제공되었습니다."),
-
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST.value(), "지원하지 않는 파일 형식입니다."),
 
 
     /**

--- a/src/main/java/com/momentree/global/service/S3Service.java
+++ b/src/main/java/com/momentree/global/service/S3Service.java
@@ -1,0 +1,11 @@
+package com.momentree.global.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface S3Service {
+    String uploadProfileImage(MultipartFile file, Long userId) throws IOException;
+
+    void deleteProfileImage(Long userId);
+}

--- a/src/main/java/com/momentree/global/service/impl/S3ServiceImpl.java
+++ b/src/main/java/com/momentree/global/service/impl/S3ServiceImpl.java
@@ -1,0 +1,119 @@
+package com.momentree.global.service.impl;
+
+import com.momentree.domain.image.entity.Image;
+import com.momentree.domain.image.repository.ImageRepository;
+import com.momentree.domain.user.entity.User;
+import com.momentree.domain.user.repository.UserRepository;
+import com.momentree.global.exception.BaseException;
+import com.momentree.global.exception.ErrorCode;
+import com.momentree.global.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3ServiceImpl implements S3Service {
+
+    private final S3Client s3Client;
+    private final ImageRepository imageRepository;
+    private final UserRepository userRepository;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value(("${cloud.aws.s3.bucket}"))
+    private String bucketName;
+
+    @Transactional
+    @Override
+    public String uploadProfileImage(MultipartFile file, Long userId) throws IOException {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_USER));
+
+        // 기존 프로필 이미지가 db에 있으면 삭제
+        Optional<Image> existingProfileImage = imageRepository.findByUserAndPostIsNull(user);
+        if (existingProfileImage.isPresent()) {
+            // db에서 삭제
+            imageRepository.delete(existingProfileImage.get());
+
+            // s3 이미지 삭제
+            String existingFileName = extractProfileFileName(existingProfileImage.get().getImageUrl());
+            deleteS3Image(existingFileName);
+        }
+
+        // s3에 업로드
+        String fileName = generateS3ProfileFileName(file);
+        uploadS3Image(file, fileName);
+
+        // db 저장
+        String fileUrl = generateS3FileUrl(fileName);
+        Image image = Image.of(fileUrl, user);
+        imageRepository.save(image);
+
+        return fileUrl;
+    }
+
+    @Transactional
+    @Override
+    public void deleteProfileImage(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_USER));
+
+        // 기존 프로필 이미지가 있는지 확인
+        Optional<Image> existingProfileImage = imageRepository.findByUserAndPostIsNull(user);
+
+        if (existingProfileImage.isPresent()) {
+            // db에서 삭제
+            imageRepository.delete(existingProfileImage.get());
+
+            // s3 이미지 삭제
+            String fileName = extractProfileFileName(existingProfileImage.get().getImageUrl());
+            deleteS3Image(fileName);
+        }
+    }
+
+    private void uploadS3Image(MultipartFile file, String fileName) throws IOException {
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .contentType(file.getContentType())
+                .build();
+
+        s3Client.putObject(putObjectRequest,
+                RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+    }
+
+    private void deleteS3Image(String fileName) {
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+        s3Client.deleteObject(deleteObjectRequest);
+    }
+
+    private String generateS3ProfileFileName(MultipartFile file) {
+        return "profile/" + UUID.randomUUID() + "-" + file.getOriginalFilename();
+    }
+
+    private String generateS3FileUrl(String fileName) {
+        return "https://" + bucketName + ".s3." + region + ".amazonaws.com/" + fileName;
+    }
+
+    private String extractProfileFileName(String fileUrl) {
+        return fileUrl.replace("https://" + bucketName + ".s3." + region + ".amazonaws.com/", "");
+    }
+
+}

--- a/src/main/java/com/momentree/global/service/impl/S3ServiceImpl.java
+++ b/src/main/java/com/momentree/global/service/impl/S3ServiceImpl.java
@@ -7,6 +7,7 @@ import com.momentree.domain.user.repository.UserRepository;
 import com.momentree.global.exception.BaseException;
 import com.momentree.global.exception.ErrorCode;
 import com.momentree.global.service.S3Service;
+import com.momentree.global.utils.FileUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,6 +31,7 @@ public class S3ServiceImpl implements S3Service {
     private final S3Client s3Client;
     private final ImageRepository imageRepository;
     private final UserRepository userRepository;
+    private final FileUtil fileUtil;
 
     @Value("${cloud.aws.region.static}")
     private String region;
@@ -54,8 +56,10 @@ public class S3ServiceImpl implements S3Service {
             deleteS3Image(existingFileName);
         }
 
-        // s3에 업로드
         String fileName = generateS3ProfileFileName(file);
+        // 파일 확장자 검사
+        fileUtil.validateFile(fileName);
+        // s3에 업로드
         uploadS3Image(file, fileName);
 
         // db 저장

--- a/src/main/java/com/momentree/global/utils/FileUtil.java
+++ b/src/main/java/com/momentree/global/utils/FileUtil.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Component
 public class FileUtil {
-    public static final List<String> ALLOWED_EXTENSIONS_IMAGE = Arrays.asList("jpg", "jpeg", "png", "gif");
+    public static final List<String> ALLOWED_EXTENSIONS_IMAGE = Arrays.asList("jpg", "jpeg", "png", "gif", "webp");
 
     public void validateFile(String fileName) {
         String fileExtension = getFileExtension(fileName);

--- a/src/main/java/com/momentree/global/utils/FileUtil.java
+++ b/src/main/java/com/momentree/global/utils/FileUtil.java
@@ -1,0 +1,25 @@
+package com.momentree.global.utils;
+
+import com.momentree.global.exception.BaseException;
+import com.momentree.global.exception.ErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class FileUtil {
+    public static final List<String> ALLOWED_EXTENSIONS_IMAGE = Arrays.asList("jpg", "jpeg", "png", "gif");
+
+    public void validateFile(String fileName) {
+        String fileExtension = getFileExtension(fileName);
+        if (!ALLOWED_EXTENSIONS_IMAGE.contains(fileExtension)) {
+            throw new BaseException(ErrorCode.INVALID_FILE_EXTENSION);
+        }
+    }
+
+    private String getFileExtension(String fileName) {
+        int dotIndex = fileName.lastIndexOf(".");
+        return dotIndex == -1 ? "" : fileName.substring(dotIndex + 1).toLowerCase();
+    }
+}


### PR DESCRIPTION
## ✨ Feature: AWS S3 기반 프로필 이미지 업로드/삭제 기능 개발

### 📝 작업 개요 (Summary)
- AWS S3를 활용한 프로필 이미지 업로드 및 삭제 기능을 구현하였습니다.

### 🎯 목표 및 완료 조건 (Goals / Done Criteria)
- [X] AWS S3 관련 의존성 및 설정 클래스(S3Config) 추가
- [X] User 정보 응답에 profileImage 필드 추가
- [X] MultipartFile 업로드 시 UUID를 활용한 고유한 파일명 생성 로직 구현
- [X] 업로드된 이미지 S3 저장 및 DB 저장 로직 구현
- [X] 사용자 프로필 이미지 삭제 시 DB 및 S3 양쪽에서 삭제되도록 구현
- [X] 파일 확장자 검사 및 유효하지 않은 확장자 업로드 시 예외 처리

### 📋 구현 상세 (Details)
- 파일 업로드 시, profile/UUID-원본파일명 형식의 경로로 업로드
- 업로드 가능한 확장자 제한 (jpg, jpeg, png, webp 등)
- 확장자 미허용 시 ErrorCode.INVALID_FILE_EXTENSION 반환
- 유저 정보 조회 시 프로필 이미지 URL 포함되도록 응답 구조 수정

### 🧩 영향 범위
- User 관련 조회 응답 구조 변경 (프로필 이미지 포함됨)
- 파일 업로드/삭제 API 추가
