### PR TITLE
feat: #38 회원 탈퇴시 이메일 전송 기능 구현 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
 	implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
 	implementation("software.amazon.awssdk:s3:2.25.4")
 
+	// JavaMailSender
+	implementation("org.springframework.boot:spring-boot-starter-mail")
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+	implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+	implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity6")
 	compileOnly("org.projectlombok:lombok")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/java/com/momentree/global/config/EmailConfig.java
+++ b/src/main/java/com/momentree/global/config/EmailConfig.java
@@ -1,0 +1,35 @@
+package com.momentree.global.config;
+
+import com.momentree.global.config.property.EmailProperty;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@RequiredArgsConstructor
+public class EmailConfig {
+
+    private final EmailProperty emailProperty;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(emailProperty.getHost());
+        mailSender.setPort(emailProperty.getPort());
+        mailSender.setUsername(emailProperty.getUsername());
+        mailSender.setPassword(emailProperty.getPassword());
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", String.valueOf(emailProperty.getProperties().getSmtp().isAuth()));
+        props.put("mail.smtp.starttls.enable", String.valueOf(emailProperty.getProperties().getSmtp().getStarttls().isEnable()));
+        props.put("mail.smtp.timeout", String.valueOf(emailProperty.getProperties().getSmtp().getTimeout()));
+
+        return mailSender;
+    }
+
+}

--- a/src/main/java/com/momentree/global/config/property/EmailProperty.java
+++ b/src/main/java/com/momentree/global/config/property/EmailProperty.java
@@ -1,0 +1,36 @@
+package com.momentree.global.config.property;
+
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "spring.mail")
+public class EmailProperty {
+    private String host;
+    private int port;
+    private String username;
+    private String password;
+    private Properties properties;
+
+    @Data
+    public static class Properties {
+        private Smtp smtp;
+
+        @Data
+        public static class Smtp {
+            private boolean auth;
+            private int timeout;
+            private Starttls starttls;
+
+            @Data
+            public static class Starttls {
+                private boolean enable;
+            }
+        }
+    }
+
+}
+

--- a/src/main/java/com/momentree/global/exception/ErrorCode.java
+++ b/src/main/java/com/momentree/global/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     /**
      * 500 : Database, Server 오류
      */
+    FAILED_TO_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR.value(), "이메일 발송에 실패하였습니다."),
     FAILED_TO_CONNECT_DATABASE(HttpStatus.INTERNAL_SERVER_ERROR.value(), "데이터베이스 연결에 실패하였습니다."),
     FAILED_TO_CONNECT_SERVER(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버와의 연결에 실패하였습니다."),
     UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예상치 못한 에러가 발생했습니다."),

--- a/src/main/java/com/momentree/global/service/EmailService.java
+++ b/src/main/java/com/momentree/global/service/EmailService.java
@@ -1,0 +1,5 @@
+package com.momentree.global.service;
+
+public interface EmailService {
+    void sendEmail(String to, String subject, String content);
+}

--- a/src/main/java/com/momentree/global/service/impl/EmailServiceImpl.java
+++ b/src/main/java/com/momentree/global/service/impl/EmailServiceImpl.java
@@ -1,0 +1,36 @@
+package com.momentree.global.service.impl;
+
+import com.momentree.global.exception.BaseException;
+import com.momentree.global.exception.ErrorCode;
+import com.momentree.global.service.EmailService;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailService {
+
+    private final JavaMailSender javaMailSender;
+
+    @Override
+    public void sendEmail(String to, String subject, String htmlContent) {
+        try {
+            MimeMessage message = javaMailSender.createMimeMessage();
+
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(htmlContent, true); // ✅ HTML 형식으로 보내기
+            helper.setFrom("mymomentree@naver.com");
+
+            javaMailSender.send(message);
+        } catch (MessagingException e) {
+            throw new BaseException(ErrorCode.FAILED_TO_SEND_EMAIL);
+        }
+    }
+}

--- a/src/main/resources/templates/Withdrawal-email.html
+++ b/src/main/resources/templates/Withdrawal-email.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            color: #333;
+        }
+
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+
+        .footer {
+            font-size: 12px;
+            color: #888;
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h2>안녕하세요, <span th:text="${username}"></span> 회원님.</h2>
+    <h2>Momentree에서의 여정을 함께해 주셔서 감사합니다.</h2>
+    <p>Momentree는 회원님의 탈퇴 요청에 따라 계정을 비활성화하고, 관련 데이터는 90일간 보관 후 안전하게 삭제됩니다.</p>
+    <p> 해당 기간 내 재가입 시 기존 데이터를 복원할 수 있으며, 90일 이후에는 복구가 불가능합니다.</p>
+    <br>
+    <p>- Momentree 팀 드림</p>
+    <div class="footer">
+        본 메일은 발신 전용 메일입니다.
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## ✨ Feature: 회원 탈퇴 시 이메일 전송 기능 구현

### 📝 작업 개요 (Summary)
회원 탈퇴 시 사용자에게 이메일을 전송하는 기능 구현

### 🎯 목표 및 완료 조건 (Goals / Done Criteria)
- [X] JavaMailSender 환경 설정
- [X] Thymeleaf를 활용한 이메일 템플릿 구성
- [x] 이메일 발송용 EmailService 구현
- [X] 회원 탈퇴 시 이메일 전송 로직 연동

### 📋 구현 상세 (Details)
- JavaMailSender를 사용해 SMTP 기반 이메일 전송 기능 설정
- Thymeleaf 템플릿 엔진을 활용해 HTML 이메일 양식 작성
- EmailService 클래스에서 이메일 본문 생성 및 전송 기능 구현
- 회원 탈퇴 처리 시 EmailService를 통해 이메일 전송 호출
- 이메일 내용에는 사용자 이름과 탈퇴 확인 메시지를 포함

### 🧩 영향 범위
- EmailService 및 관련 구성 파일 (MailConfig 등)
- 회원 관리 도메인 (UserService)