### PR TITLE
feat: #41 PostResponseDto에서 User 엔티티 대신 UserResponseDto를 반환하도록 수정

### DIFF
--- a/src/main/java/com/momentree/domain/post/post/dto/response/PostResponseDto.java
+++ b/src/main/java/com/momentree/domain/post/post/dto/response/PostResponseDto.java
@@ -1,13 +1,26 @@
 package com.momentree.domain.post.post.dto.response;
 
 import com.momentree.domain.post.post.entity.Post;
+import com.momentree.domain.user.dto.response.UserInfoResponseDto;
+
+import java.time.LocalDateTime;
 
 public record PostResponseDto(
-    String content
+    Long postId,
+    String content,
+    UserInfoResponseDto userId,
+    Long loginUserId,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
 ) {
-    public static PostResponseDto from(Post post) {
+    public static PostResponseDto of(Post post, Long loginUserId) {
         return new PostResponseDto(
-                post.getContent()
+                post.getId(),
+                post.getContent(),
+                UserInfoResponseDto.from(post.getUser()),
+                loginUserId,
+                post.getCreatedAt(),
+                post.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/momentree/domain/post/post/service/Impl/PostServiceImpl.java
+++ b/src/main/java/com/momentree/domain/post/post/service/Impl/PostServiceImpl.java
@@ -43,7 +43,7 @@ public class PostServiceImpl implements PostService {
 
         postRepository.save(post);
 
-        return PostResponseDto.from(post);
+        return PostResponseDto.of(post, loginUser.getUserId());
     }
 
     @Override
@@ -55,7 +55,7 @@ public class PostServiceImpl implements PostService {
         List<Post> posts = postRepository.findAllByCoupleId(couple.getId());
 
         return posts.stream()
-                .map(PostResponseDto :: from)
+                .map(post -> PostResponseDto.of(post, loginUser.getUserId()))
                 .collect(Collectors.toList());
     }
 
@@ -74,7 +74,7 @@ public class PostServiceImpl implements PostService {
         } else {
             throw new BaseException(ErrorCode.POST_STATUS_NOT_PUBLISHED);
         }
-        return PostResponseDto.from(post);
+        return PostResponseDto.of(post, loginUser.getUserId());
     }
 
     @Override

--- a/src/main/java/com/momentree/domain/user/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/com/momentree/domain/user/dto/response/UserInfoResponseDto.java
@@ -1,0 +1,16 @@
+package com.momentree.domain.user.dto.response;
+
+
+import com.momentree.domain.user.entity.User;
+
+public record UserInfoResponseDto(
+        Long userId,
+        String userName
+) {
+    public static UserInfoResponseDto from(User user) {
+        return new UserInfoResponseDto(
+                user.getId(),
+                user.getUsername()
+                );
+    }
+}


### PR DESCRIPTION
## 개발 내용
- User 객체 대신 Dto를 반환함으로써 영속성 컨텍스트 문제 해결
- 프론트엔드에서 내 게시글임을 확인하기 위해 추가했습니다.
